### PR TITLE
Fjerne 'Virksomhet' i graf-legend dersom historikk for underenhet er tom

### DIFF
--- a/src/GrafOgTabell/Graf/Graf.tsx
+++ b/src/GrafOgTabell/Graf/Graf.tsx
@@ -7,13 +7,14 @@ import grafLinjer from './grafLinjer';
 import './Graf.less';
 import 'nav-frontend-tabell-style';
 import { Sykefraværshistorikk, SykefraværshistorikkType } from '../../api/sykefraværshistorikk';
-import { hentFørsteKvartalFraAlleÅreneIDatagrunnlaget, lagTickString } from './graf-utils';
+import {
+    getLinjerSomMatcherHistorikk,
+    hentFørsteKvartalFraAlleÅreneIDatagrunnlaget,
+    lagTickString,
+} from './graf-utils';
 import XAkseTick from './XAkseTick';
 import { useInnerWidth } from '../../utils/innerWidth-hook';
-import {
-    historikkHarOverordnetEnhet,
-    konverterTilKvartalsvisSammenligning,
-} from '../../utils/sykefraværshistorikk-utils';
+import { konverterTilKvartalsvisSammenligning } from '../../utils/sykefraværshistorikk-utils';
 
 interface Props {
     sykefraværshistorikk: Sykefraværshistorikk[];
@@ -55,8 +56,6 @@ const Graf: FunctionComponent<Props> = props => {
         historikk => historikk.type === SykefraværshistorikkType.BRANSJE
     );
 
-    const harOverordnetEnhet = historikkHarOverordnetEnhet(props.sykefraværshistorikk);
-
     const punkterPåXAksenSomSkalMarkeres: string[] = hentFørsteKvartalFraAlleÅreneIDatagrunnlaget(
         kvartalsvisSammenligning
     ).map(årstallOgKvartal => lagTickString(årstallOgKvartal.årstall, årstallOgKvartal.kvartal));
@@ -95,7 +94,7 @@ const Graf: FunctionComponent<Props> = props => {
                     labelForType(SykefraværshistorikkType.SEKTOR),
                     labelForType(SykefraværshistorikkType.LAND),
                     harBransje,
-                    harOverordnetEnhet
+                    getLinjerSomMatcherHistorikk(props.sykefraværshistorikk)
                 )}
                 {grafLinjer()}
             </LineChart>

--- a/src/GrafOgTabell/Graf/graf-utils.ts
+++ b/src/GrafOgTabell/Graf/graf-utils.ts
@@ -1,8 +1,15 @@
-import {KvartalsvisSammenligning, ÅrstallOgKvartal} from '../../utils/sykefraværshistorikk-utils';
+import { KvartalsvisSammenligning, ÅrstallOgKvartal } from '../../utils/sykefraværshistorikk-utils';
+import { Sykefraværshistorikk, SykefraværshistorikkType } from '../../api/sykefraværshistorikk';
 
 export type SymbolType = 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye';
 
-export type Linje = 'virksomhet' | 'overordnetEnhet' | 'næringEllerBransje' | 'sektor' | 'land' | string;
+export type Linje =
+    | 'virksomhet'
+    | 'overordnetEnhet'
+    | 'næringEllerBransje'
+    | 'sektor'
+    | 'land'
+    | string;
 
 interface GrafConfig {
     tooltipsnavn: any;
@@ -43,10 +50,10 @@ export const getFarge = (name: Linje): SymbolType =>
 
 export const getTooltipsnavn = (name: Linje, harBransje: boolean): string => {
     if (name === 'næringEllerBransje') {
-        return harBransje? 'Bransje' : 'Næring';
+        return harBransje ? 'Bransje' : 'Næring';
     }
     return name in grafConfig.tooltipsnavn ? grafConfig.tooltipsnavn[name] : 'Prosent';
-}
+};
 
 export const hentFørsteKvartalFraAlleÅreneIDatagrunnlaget = (
     kvartalsvisSammenligning: KvartalsvisSammenligning[]
@@ -60,3 +67,37 @@ export const hentFørsteKvartalFraAlleÅreneIDatagrunnlaget = (
 
 export const lagTickString = (årstall: number, kvartal: number) =>
     årstall + ', ' + kvartal + '. kvartal';
+
+export const getLinjerSomMatcherHistorikk = (
+    sykefraværshistorikk: Sykefraværshistorikk[]
+): Linje[] => {
+    let linjer: Linje[] = [...grafConfig.linjer];
+    console.log(" ----> the lines STEP0: " + JSON.stringify(linjer));
+
+    if (
+        !sykefraværshistorikk.find(
+            historikk =>
+                historikk.type === SykefraværshistorikkType.OVERORDNET_ENHET &&
+                historikk.kvartalsvisSykefraværsprosent.length > 0
+        )
+    ) {
+        console.log("Har funnet OVERORDNET_ENHET uten data");
+        linjer = linjer.filter(name => name !== 'overordnetEnhet');
+        console.log(" ----> the lines STEP1: " + JSON.stringify(linjer));
+    }
+
+    if (
+        !sykefraværshistorikk.find(
+            historikk =>
+                historikk.type === SykefraværshistorikkType.VIRKSOMHET &&
+                historikk.kvartalsvisSykefraværsprosent.length > 0
+        )
+    ) {
+        console.log("Har funnet VIRKSOMHET uten data");
+        linjer = linjer.filter(name => name !== 'virksomhet');
+        console.log(" ----> the lines STEP2: " + JSON.stringify(linjer));
+    }
+
+    console.log(" ----> the lines FINAL: " + JSON.stringify(linjer));
+    return linjer;
+};

--- a/src/GrafOgTabell/Graf/graf-utils.ts
+++ b/src/GrafOgTabell/Graf/graf-utils.ts
@@ -72,7 +72,6 @@ export const getLinjerSomMatcherHistorikk = (
     sykefraværshistorikk: Sykefraværshistorikk[]
 ): Linje[] => {
     let linjer: Linje[] = [...grafConfig.linjer];
-    console.log(" ----> the lines STEP0: " + JSON.stringify(linjer));
 
     if (
         !sykefraværshistorikk.find(
@@ -81,9 +80,7 @@ export const getLinjerSomMatcherHistorikk = (
                 historikk.kvartalsvisSykefraværsprosent.length > 0
         )
     ) {
-        console.log("Har funnet OVERORDNET_ENHET uten data");
         linjer = linjer.filter(name => name !== 'overordnetEnhet');
-        console.log(" ----> the lines STEP1: " + JSON.stringify(linjer));
     }
 
     if (
@@ -93,11 +90,8 @@ export const getLinjerSomMatcherHistorikk = (
                 historikk.kvartalsvisSykefraværsprosent.length > 0
         )
     ) {
-        console.log("Har funnet VIRKSOMHET uten data");
         linjer = linjer.filter(name => name !== 'virksomhet');
-        console.log(" ----> the lines STEP2: " + JSON.stringify(linjer));
     }
 
-    console.log(" ----> the lines FINAL: " + JSON.stringify(linjer));
     return linjer;
 };

--- a/src/GrafOgTabell/Graf/grafLegend/grafLegend.tsx
+++ b/src/GrafOgTabell/Graf/grafLegend/grafLegend.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import './grafLegend.less';
 import SymbolSvg from '../SymbolSvg';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
-import { getFarge, getSymbol, grafConfig } from '../graf-utils';
+import { getFarge, getSymbol, Linje } from '../graf-utils';
 
 const grafLegend = (
     labelVirksomhet: string,
@@ -12,7 +12,7 @@ const grafLegend = (
     labelSektor: string,
     labelLand: string,
     harBransje: boolean,
-    harOverordnetEnhet: boolean
+    linjer: Linje[]
 ) => {
     const labels = {
         virksomhet: (
@@ -65,10 +65,6 @@ const grafLegend = (
             ))}
         </ul>
     );
-
-    const linjer = harOverordnetEnhet
-        ? grafConfig.linjer
-        : grafConfig.linjer.filter(name => name !== 'overordnetEnhet');
 
     return (
         <Legend

--- a/src/mocking/sykefraværshistorikk.ts
+++ b/src/mocking/sykefraværshistorikk.ts
@@ -84,6 +84,34 @@ const lagHistorikkMedLandSektor = (): Sykefraværshistorikk[] => {
     ];
 };
 
+const lagHistorikkMedLandSektorOgNæringMenIngenDataForOverordnetEnhetEllerUnderenhet = (): Sykefraværshistorikk[] => {
+    return [
+        ...lagHistorikkMedLandSektor(),
+        {
+            type: SykefraværshistorikkType.NÆRING,
+            label: 'Produksjon av nærings- og nytelsesmidler',
+            kvartalsvisSykefraværsprosent: genererHistorikk(
+                { årstall: 2014, kvartal: 2 },
+                20,
+                6.7,
+                2,
+                0.4,
+                0
+            ),
+        },
+        {
+            type: SykefraværshistorikkType.VIRKSOMHET,
+            label: 'FLESK OG FISK AS',
+            kvartalsvisSykefraværsprosent: [],
+        },
+        {
+            type: SykefraværshistorikkType.OVERORDNET_ENHET,
+            label: 'THE FISHING GROUP',
+            kvartalsvisSykefraværsprosent: [],
+        },
+    ];
+};
+
 const lagHistorikkUtenBransjeOgNæring = (): Sykefraværshistorikk[] => [
     ...lagHistorikkMedLandSektor(),
     {
@@ -182,8 +210,9 @@ const lagHistorikkMedLikHistorikkForUnderenhetOgOverordnetEnhet = () => {
 
 export const getSykefraværshistorikkMock = (orgnr: String): Sykefraværshistorikk[] => {
     switch (orgnr) {
+        case '333333333':
+            return lagHistorikkMedLandSektorOgNæringMenIngenDataForOverordnetEnhetEllerUnderenhet();
         case '666666666':
-            console.log('Lage historikk for: 666666666')
             return lagHistorikkMedLikHistorikkForUnderenhetOgOverordnetEnhet();
         case '888888888':
             return lagHistorikkBransje();


### PR DESCRIPTION
Dette kan testes lokalt ved å kjøre `yarn mock` og velge bedrift `333333333`