### PR TITLE
Sende antall ansatte i bedriften til Amplitude

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import FeilFraAltinnSide from './FeilSider/FeilFraAltinnSide/FeilFraAltinnSide';
 import GrafOgTabell from './GrafOgTabell/GrafOgTabell';
 import { useRestSykefraværshistorikk } from './api/sykefraværshistorikk';
 import amplitude from './utils/amplitude';
+import { trackBedriftsmetrikker, useRestBedriftsmetrikker } from './api/bedriftsmetrikker';
 
 export const PATH_FORSIDE = '/';
 export const PATH_KALKULATOR = '/kalkulator';
@@ -41,12 +42,14 @@ const AppContent: FunctionComponent = () => {
     const restOrganisasjonstre = useRestOrganisasjonstre();
     const restSykefraværshistorikk = useRestSykefraværshistorikk(orgnr);
     const restFeatureToggles = useRestFeatureToggles();
+    const restBedriftsmetrikker = useRestBedriftsmetrikker(orgnr);
 
     let innhold;
 
     if (
         restOrganisasjonstre.status === RestStatus.LasterInn ||
-        restFeatureToggles.status === RestStatus.LasterInn
+        restFeatureToggles.status === RestStatus.LasterInn ||
+        restBedriftsmetrikker.status === RestStatus.LasterInn
     ) {
         innhold = <Lasteside />;
     } else if (restOrganisasjonstre.status === RestStatus.IkkeInnlogget) {
@@ -54,6 +57,9 @@ const AppContent: FunctionComponent = () => {
     } else if (restOrganisasjonstre.status !== RestStatus.Suksess) {
         innhold = <FeilFraAltinnSide />;
     } else {
+        if (restBedriftsmetrikker.status === RestStatus.Suksess) {
+            trackBedriftsmetrikker(restBedriftsmetrikker.data);
+        }
         const skalViseGraf = restFeatureToggles.data['arbeidsgiver.lanser-graf'];
         innhold = (
             <>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -7,12 +7,16 @@ import {
     Sykefraværshistorikk,
     SykefraværshistorikkType,
 } from './sykefraværshistorikk';
-import amplitude from "../utils/amplitude";
+import amplitude from '../utils/amplitude';
+import { RestBedriftsmetrikker } from './bedriftsmetrikker';
 
 const sykefraværshistorikkPath = (orgnr: string) =>
     `${BASE_PATH}/api/${orgnr}/sykefravarshistorikk`;
+
 const featureTogglesPath = (features: string[]) =>
     `${BASE_PATH}/api/feature?` + features.map(featureNavn => `feature=${featureNavn}`).join('&');
+
+const bedriftsmetrikkerPath = (orgnr: string) => `${BASE_PATH}/api/${orgnr}/bedriftsmetrikker`;
 
 export const hentRestSykefraværshistorikk = async (
     orgnr: string
@@ -65,6 +69,24 @@ export const hentRestFeatureToggles = async (
     };
 };
 
+export const hentRestBedriftsmetrikker = async (orgnr: string): Promise<RestBedriftsmetrikker> => {
+    const response = await fetch(bedriftsmetrikkerPath(orgnr), {
+        method: 'GET',
+        credentials: 'include',
+    });
+
+    const restStatus = getRestStatus(response.status);
+    if (restStatus === RestStatus.Suksess) {
+        return {
+            status: RestStatus.Suksess,
+            data: await response.json(),
+        };
+    }
+    return {
+        status: restStatus,
+    };
+};
+
 export const filtrerBortOverordnetEnhetshistorikkHvisDenErLikUnderenhet = (
     data: Sykefraværshistorikk[]
 ): Sykefraværshistorikk[] => {
@@ -83,10 +105,14 @@ export const filtrerBortOverordnetEnhetshistorikkHvisDenErLikUnderenhet = (
             sykefraværshistorikkForUnderenhet
         )
     ) {
-        amplitude.logEvent('#sykefravarsstatistikk-segmentering valgt underenhet er lik overordnet enhet');
+        amplitude.logEvent(
+            '#sykefravarsstatistikk-segmentering valgt underenhet er lik overordnet enhet'
+        );
         nullstillOverordnetEnhetshistorikk(data);
     } else {
-        amplitude.logEvent('#sykefravarsstatistikk-segmentering valgt underenhet er ulik overordnet enhet');
+        amplitude.logEvent(
+            '#sykefravarsstatistikk-segmentering valgt underenhet er ulik overordnet enhet'
+        );
     }
 
     return data;

--- a/src/api/bedriftsmetrikker.ts
+++ b/src/api/bedriftsmetrikker.ts
@@ -1,0 +1,55 @@
+import { RestRessurs, RestStatus } from './api-utils';
+import { useEffect, useState } from 'react';
+import { hentRestBedriftsmetrikker } from './api';
+import amplitude from '../utils/amplitude';
+
+export type Næringskode5Siffer = {
+    kode: number;
+    beskrivelse: string;
+};
+
+export interface Bedriftsmetrikker {
+    næringskode5Siffer: Næringskode5Siffer;
+    antallAnsatte: number;
+}
+
+export type RestBedriftsmetrikker = RestRessurs<Bedriftsmetrikker>;
+
+export const useRestBedriftsmetrikker = (orgnr: string | undefined): RestBedriftsmetrikker => {
+    const [restBedriftsmetrikker, setRestBedriftsmetrikker] = useState<RestBedriftsmetrikker>({
+        status: RestStatus.IkkeLastet,
+    });
+
+    useEffect(() => {
+        if (orgnr) {
+            setRestBedriftsmetrikker({
+                status: RestStatus.IkkeLastet,
+            });
+            const hentRestBedriftsmetrikkerOgSettState = async () => {
+                setRestBedriftsmetrikker(await hentRestBedriftsmetrikker(orgnr));
+            };
+            hentRestBedriftsmetrikkerOgSettState();
+        }
+    }, [orgnr]);
+
+    return restBedriftsmetrikker;
+};
+
+export const trackBedriftsmetrikker = (målinger: Bedriftsmetrikker) => {
+    let størrelse: string;
+    const antallAnsatte = målinger.antallAnsatte;
+    if (antallAnsatte === 0) {
+        størrelse = 'ingen';
+    } else if (antallAnsatte >= 1 && antallAnsatte <= 4) {
+        størrelse = 'sma-1-4';
+    } else if (antallAnsatte >= 5 && antallAnsatte <= 19) {
+        størrelse = 'sma-5-19';
+    } else if (antallAnsatte >= 20 && antallAnsatte <= 49) {
+        størrelse = 'medium-20-49';
+    } else if (antallAnsatte >= 50 && antallAnsatte <= 99) {
+        størrelse = 'medium-50-99';
+    } else {
+        størrelse = '-store-100+';
+    }
+    amplitude.logEvent(`#sykefravarsstatistikk-segmentering-storrelse-${størrelse}`);
+};

--- a/src/mocking/mock.ts
+++ b/src/mocking/mock.ts
@@ -28,6 +28,25 @@ if (MOCK_SYKEFRAVÆRSSTATISTIKK_API) {
             delay: 1000,
         }
     );
+    fetchMock.get(
+        'express:/sykefravarsstatistikk/api/:orgnr/bedriftsmetrikker',
+        url => {
+            const orgnr = url.match(/[0-9]{9}/)![0];
+            if (orgnr === '101010101') {
+                return 500;
+            }
+            return {
+                antallAnsatte: 99,
+                næringskode5Siffer: {
+                    kode: '10300',
+                    beskrivelse: 'Trygdeordninger underlagt offentlig forvaltning',
+                },
+            };
+        },
+        {
+            delay: 500,
+        }
+    );
 }
 
 if (MOCK_ENHETSREGISTERET) {


### PR DESCRIPTION
Det gjøres to ting her: uthenting av `bedriftsmetrikker` i api-et, og segmentering av besøkende ifm antall ansatte i bedriften vedkommende representerer