### PR TITLE
Sende metrikker om sykefravaærprosent segmenter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,8 +57,11 @@ const AppContent: FunctionComponent = () => {
     } else if (restOrganisasjonstre.status !== RestStatus.Suksess) {
         innhold = <FeilFraAltinnSide />;
     } else {
-        if (restBedriftsmetrikker.status === RestStatus.Suksess) {
-            trackBedriftsmetrikker(restBedriftsmetrikker.data);
+        if (
+            restBedriftsmetrikker.status === RestStatus.Suksess &&
+            restSykefraværshistorikk.status === RestStatus.Suksess
+        ) {
+            trackBedriftsmetrikker(restBedriftsmetrikker.data, restSykefraværshistorikk.data);
         }
         const skalViseGraf = restFeatureToggles.data['arbeidsgiver.lanser-graf'];
         innhold = (

--- a/src/api/bedriftsmetrikker.ts
+++ b/src/api/bedriftsmetrikker.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/sykefraværshistorikk-utils';
 
 enum SegmenteringSykefraværprosent {
+    IKKE_SATT = 'IKKE_SATT',
     NULL = '0',
     LAVERE_ENN_TO_OG_IKKE_NULL = '<2',
     TO_TIL_FIRE = '2-4',
@@ -23,10 +24,7 @@ enum SegmenteringSykefraværprosent {
     TI_TIL_TOLV = '10-12',
     TOLV_TIL_FJORTEN = '12-14',
     FJORTEN_TIL_SEKSTEN = '14-16',
-    OVER_SEKSTEN = '>16',
-    BRANSJE = 'BRANSJE',
-    VIRKSOMHET = 'VIRKSOMHET',
-    OVERORDNET_ENHET = 'OVERORDNET_ENHET',
+    OVER_SEKSTEN = '>16'
 }
 
 export type Næringskode5Siffer = {
@@ -127,7 +125,7 @@ const tilSegmenteringSykefraværprosent = (prosent: number): SegmenteringSykefra
     } else if (prosent >= 16) {
         segmenteringSykefraværprosent = SegmenteringSykefraværprosent.OVER_SEKSTEN;
     } else {
-        segmenteringSykefraværprosent = SegmenteringSykefraværprosent.NULL;
+        segmenteringSykefraværprosent = SegmenteringSykefraværprosent.IKKE_SATT;
     }
     return segmenteringSykefraværprosent;
 };

--- a/src/utils/sykefraværshistorikk-utils.ts
+++ b/src/utils/sykefraværshistorikk-utils.ts
@@ -25,7 +25,7 @@ const TOM_PROSENT: Sykefraværsprosent = {
     tapteDagsverk: undefined,
     muligeDagsverk: undefined,
 };
-const finnProsent = (
+export const finnProsent = (
     historikkListe: Sykefraværshistorikk[],
     årstallOgKvartal: ÅrstallOgKvartal,
     type: SykefraværshistorikkType
@@ -65,7 +65,7 @@ const mapTilKvartalsvisSammenligning = (
         };
     });
 };
-const beregnHvilkeÅrstallOgKvartalerSomSkalVises = (
+export const beregnHvilkeÅrstallOgKvartalerSomSkalVises = (
     historikkListe: Sykefraværshistorikk[]
 ): ÅrstallOgKvartal[] => {
     return historikkListe


### PR DESCRIPTION
Henter sykefraværprosent til virksomhet fra historikk og sender tilsvarende segmentet til Amplitude hvis prosenten er tilgjengelig.