### PR TITLE
Kalkisfix

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -8,7 +8,7 @@ env:
 jobs:
     compile-test-and-build:
         name: Build and run tests
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/kalkisfix'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
@@ -38,7 +38,7 @@ jobs:
 
     deploy-to-dev:
         name: Deploy to dev-sbs
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/kalkisfix'
         needs: compile-test-and-build
         runs-on: ubuntu-latest
         steps:

--- a/src/Forside/Historikkpanel/Historikkpanel.tsx
+++ b/src/Forside/Historikkpanel/Historikkpanel.tsx
@@ -23,6 +23,7 @@ const Historikkpanel: FunctionComponent = () => {
                 onClick={() => {
                     sendEvent('sykefravarsstatistikk.klikk-til-historikk');
                     amplitude.logEvent('#sykefravarsstatistikk-forside historikk-klikk');
+                    amplitude.logEvent('#sykefravarsstatistikk-forside noe-klikket-pa');
                 }}
             >
                 Gå til sykefraværshistorikken

--- a/src/Forside/IAwebpanel/IAwebpanel.tsx
+++ b/src/Forside/IAwebpanel/IAwebpanel.tsx
@@ -31,6 +31,7 @@ const IAwebpanel: React.FunctionComponent = () => {
                     onClick={() => {
                         sendEvent('sykefravarsstatistikk.klikk-til-iaweb');
                         amplitude.logEvent('#sykefravarsstatistikk-forside iaweb-klikk');
+                        amplitude.logEvent('#sykefravarsstatistikk-forside noe-klikket-pa');
                     }}
                 >
                     Gå til IA-web

--- a/src/Forside/Kalkulatorpanel/KalkulatorPanel.tsx
+++ b/src/Forside/Kalkulatorpanel/KalkulatorPanel.tsx
@@ -30,6 +30,7 @@ const KalkulatorPanel: FunctionComponent = () => {
                 onClick={() => {
                     sendEvent('sykefravarsstatistikk.klikk-til-kalkulator');
                     amplitude.logEvent('#sykefravarsstatistikk-forside kalkulator-klikk');
+                    amplitude.logEvent('#sykefravarsstatistikk-forside noe-klikket-pa');
                 }}
             >
                 Gå til kostnadskalkulatoren

--- a/src/Forside/VideoerPanel/VideoerPanel.tsx
+++ b/src/Forside/VideoerPanel/VideoerPanel.tsx
@@ -17,10 +17,10 @@ const VideoerPanel: FunctionComponent<{ visNyttDesign: boolean }> = props => {
         <PanelBase className="videoerpanel">
             <Systemtittel className="videoerpanel__overskrift" tag="h2">
                 <Kalkulatorikon className="videoerpanel__illustrasjon" />
-                Informasjonsvideoer
+                Videoer
             </Systemtittel>
             <Normaltekst className="videoerpanel__ingress">
-                Se NAVs informasjonsvideoer om hvordan du kan jobbe med sykefravær og arbeidsmiljø.
+                Se NAVs videoer om hvordan du kan jobbe med sykefravær og arbeidsmiljø.
             </Normaltekst>
 
             <EksternLenke

--- a/src/Forside/VideoerPanel/VideoerPanelTogglet.tsx
+++ b/src/Forside/VideoerPanel/VideoerPanelTogglet.tsx
@@ -28,6 +28,7 @@ const VideoerPanelTogglet: FunctionComponent = () => (
                 onClick={() => {
                     sendEvent('sykefravarsstatistikk.klikk-til-redusering-av-sykefravar');
                     amplitude.logEvent('#sykefravarsstatistikk-forside videoer folgeopp-klikk');
+                    amplitude.logEvent('#sykefravarsstatistikk-forside noe-klikket-pa');
                 }}
             >
                 Følge opp sykefravær
@@ -39,6 +40,7 @@ const VideoerPanelTogglet: FunctionComponent = () => (
                 onClick={() => {
                     sendEvent('sykefravarsstatistikk.klikk-til-forebygge-arbeidsmiljoet');
                     amplitude.logEvent('#sykefravarsstatistikk-forside videoer forebygge-klikk');
+                    amplitude.logEvent('#sykefravarsstatistikk-forside noe-klikket-pa');
                 }}
             >
                 Forebygge sykefravær

--- a/src/Kalkulator/Kalkulator.tsx
+++ b/src/Kalkulator/Kalkulator.tsx
@@ -102,6 +102,11 @@ const Kalkulator: FunctionComponent<Props> = props => {
         return !(verdi < 0);
     };
 
+    const amplitudeloggeventtekst =
+    antallTapteDagsverkEllerProsent === AntallTapteDagsverkEllerProsent.SYKEFRAVÆRSPROSENT
+        ? '#sykefravarsstatistikk_kalkulator-input-prosent_endret'
+        : '#sykefravarsstatistikk_kalkulator-input-dagsverk_endret'
+
     function setVerdiMuligeDagsverk(verdi: number) {
         if (!skalViseDefaultTapteDagsverk && erVerdiAkseptabelt(verdi)) {
             setMuligeDagsverk(verdi);
@@ -118,7 +123,7 @@ const Kalkulator: FunctionComponent<Props> = props => {
                 onChange={event => setVerdiMuligeDagsverk(parseFloat(event.target.value))}
                 onClick={() => {
                     amplitude.logEvent(
-                        '#sykefravarsstatistikk-kalkulator antall-mulige-dagsverk input-klikk'
+                        amplitudeloggeventtekst
                     );
                 }}
                 value={muligeDagsverk}
@@ -274,6 +279,9 @@ const Kalkulator: FunctionComponent<Props> = props => {
                         setAntalltapteDagsverkEllerProsent(
                             AntallTapteDagsverkEllerProsent.ANTALLTAPTEDAGSVERK
                         );
+                        amplitude.logEvent(
+                            'sykefravarsstatistikk_kalkulator-radio-basertpadagsverk_klikk'
+                        );
                     }}
                 />
                 <Radio
@@ -282,6 +290,9 @@ const Kalkulator: FunctionComponent<Props> = props => {
                     onChange={() => {
                         setAntalltapteDagsverkEllerProsent(
                             AntallTapteDagsverkEllerProsent.SYKEFRAVÆRSPROSENT
+                        );
+                        amplitude.logEvent(
+                            'sykefravarsstatistikk_kalkulator-radio-basertpaprosent_klikk'
                         );
                     }}
                 />
@@ -312,7 +323,7 @@ const Kalkulator: FunctionComponent<Props> = props => {
                             onChange={event => setKostnadDagsverk(parseInt(event.target.value))}
                             onClick={() => {
                                 amplitude.logEvent(
-                                    '#sykefravarsstatistikk-kalkulator kostnad input-klikk'
+                                    amplitudeloggeventtekst
                                 );
                             }}
                             value={kostnadDagsverk || ''}
@@ -348,7 +359,7 @@ const Kalkulator: FunctionComponent<Props> = props => {
                             }
                             onClick={() => {
                                 amplitude.logEvent(
-                                    '#sykefravarsstatistikk-kalkulator nåværende-tapte-dagsverk-eller-prosent input-klikk'
+                                    amplitudeloggeventtekst
                                 );
                             }}
                             value={
@@ -385,7 +396,7 @@ const Kalkulator: FunctionComponent<Props> = props => {
                             }
                             onClick={() => {
                                 amplitude.logEvent(
-                                    '#sykefravarsstatistikk-kalkulator ønsket-tapte-dagsverk-eller-prosentr input-klikk'
+                                    amplitudeloggeventtekst
                                 );
                             }}
                             value={

--- a/src/Kalkulator/Kalkulator.tsx
+++ b/src/Kalkulator/Kalkulator.tsx
@@ -280,7 +280,7 @@ const Kalkulator: FunctionComponent<Props> = props => {
                             AntallTapteDagsverkEllerProsent.ANTALLTAPTEDAGSVERK
                         );
                         amplitude.logEvent(
-                            'sykefravarsstatistikk_kalkulator-radio-basertpadagsverk_klikk'
+                            '#sykefravarsstatistikk_kalkulator-radio-basertpadagsverk_klikk'
                         );
                     }}
                 />
@@ -292,7 +292,7 @@ const Kalkulator: FunctionComponent<Props> = props => {
                             AntallTapteDagsverkEllerProsent.SYKEFRAVÆRSPROSENT
                         );
                         amplitude.logEvent(
-                            'sykefravarsstatistikk_kalkulator-radio-basertpaprosent_klikk'
+                            '#sykefravarsstatistikk_kalkulator-radio-basertpaprosent_klikk'
                         );
                     }}
                 />


### PR DESCRIPTION
**Eventer på forsiden**
Lagt til én ekstra event på alle lenker på forsiden av SF statistikk. Slik at vi kan ha en event som sier noe om brukeren har klikket på "noe" på forsiden. Eventen har derfor samme navn på alle lenkene.

**Kalkulatoren**
Har lagt til eventer på radioknappene samt alle inputfeltene for både prosent og dagsverk.

