### PR TITLE
Måle time on site

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const AppContent: FunctionComponent = () => {
     const location = useLocation();
 
     useSetUserProperties();
-    useMålingAvTidsbruk('hele appen', 1, 2, 3, 10);
+    useMålingAvTidsbruk('hele appen', 5, 30, 120, 300);
 
     const brukerHarIkkeTilgangTilNoenOrganisasjoner =
         restOrganisasjoner.status === RestStatus.Suksess && restOrganisasjoner.data.length === 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import {
     bedriftsmetrikkerContext,
     BedriftsmetrikkerProvider,
 } from './utils/bedriftsmetrikkerContext';
-import { sendEventDirekte } from './amplitude/amplitude';
+import { sendEventDirekte, useMålingAvTidsbruk } from './amplitude/amplitude';
 import {
     sykefraværshistorikkContext,
     SykefraværshistorikkProvider,
@@ -73,6 +73,7 @@ const AppContent: FunctionComponent = () => {
     const location = useLocation();
 
     useSetUserProperties();
+    useMålingAvTidsbruk('kalkulator', 1, 2, 3, 10);
 
     const brukerHarIkkeTilgangTilNoenOrganisasjoner =
         restOrganisasjoner.status === RestStatus.Suksess && restOrganisasjoner.data.length === 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const AppContent: FunctionComponent = () => {
     const location = useLocation();
 
     useSetUserProperties();
-    useMålingAvTidsbruk('kalkulator', 1, 2, 3, 10);
+    useMålingAvTidsbruk('hele appen', 1, 2, 3, 10);
 
     const brukerHarIkkeTilgangTilNoenOrganisasjoner =
         restOrganisasjoner.status === RestStatus.Suksess && restOrganisasjoner.data.length === 0;

--- a/src/GrafOgTabell/GrafOgTabell.tsx
+++ b/src/GrafOgTabell/GrafOgTabell.tsx
@@ -9,7 +9,7 @@ import { RestStatus } from '../api/api-utils';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { scrollToBanner } from '../utils/scrollUtils';
-import { useSendEvent } from '../amplitude/amplitude';
+import { useMålingAvTidsbruk, useSendEvent } from '../amplitude/amplitude';
 import ManglerRettigheterIAltinnSide from '../FeilSider/ManglerRettigheterIAltinnSide/ManglerRettigheterIAltinnSide';
 import { RestAltinnOrganisasjoner } from '../api/altinnorganisasjon-api';
 
@@ -23,6 +23,7 @@ const GrafOgTabell: FunctionComponent<Props> = (props) => {
     useEffect(() => {
         scrollToBanner();
     }, []);
+    useMålingAvTidsbruk('kalkulator', 5, 30, 120);
 
     const [grafEllerTabell, setGrafEllerTabell] = useState<'graf' | 'tabell'>('graf');
 

--- a/src/Kalkulator/KalkulatorABTest.tsx
+++ b/src/Kalkulator/KalkulatorABTest.tsx
@@ -22,6 +22,7 @@ export const KalkulatorABTest: FunctionComponent<Props> = ({ restSykefraværshis
             sendEvent('kalkulator', 'vist', { kalkulatorversjon: 'ny' });
             return <KalkulatorNy restSykefraværshistorikk={restSykefraværshistorikk} />;
         } else {
+            // TODO Denne sendes kanskje for ofte; må fikses når vi avslutter AB-testen
             sendEvent('kalkulator', 'vist', { kalkulatorversjon: 'gammel' });
             return <KalkulatorGammel restSykefraværshistorikk={restSykefraværshistorikk} />;
         }

--- a/src/Kalkulator/KalkulatorABTest.tsx
+++ b/src/Kalkulator/KalkulatorABTest.tsx
@@ -3,7 +3,7 @@ import KalkulatorGammel from './KalkulatorGammel/KalkulatorGammel';
 import { RestSykefraværshistorikk } from '../api/sykefraværshistorikk';
 import { featureTogglesContext } from '../utils/FeatureTogglesContext';
 import { RestStatus } from '../api/api-utils';
-import { useSendEvent } from '../amplitude/amplitude';
+import { useMålingAvTidsbruk, useSendEvent } from '../amplitude/amplitude';
 import Lasteside from '../Lasteside/Lasteside';
 import KalkulatorNy from './KalkulatorNy/KalkulatorNy';
 
@@ -14,6 +14,7 @@ interface Props {
 export const KalkulatorABTest: FunctionComponent<Props> = ({ restSykefraværshistorikk }) => {
     const restFeatureToggles = useContext(featureTogglesContext);
     const sendEvent = useSendEvent();
+    useMålingAvTidsbruk('kalkulator', 5, 30, 120);
 
     if (restFeatureToggles.status === RestStatus.Suksess) {
         const skalBrukeNyKalkulator = restFeatureToggles.data['arbeidsgiver.kalkulator-abtesting'];

--- a/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
+++ b/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
@@ -4,7 +4,7 @@ import './KalkulatorNy.less';
 import { scrollToBanner } from '../../utils/scrollUtils';
 import { RestSykefraværshistorikk } from '../../api/sykefraværshistorikk';
 import { Kalkulatorvariant } from '../kalkulator-utils';
-import { useMålingAvTidsbruk, useSendEvent } from '../../amplitude/amplitude';
+import { useSendEvent } from '../../amplitude/amplitude';
 import { KalkulatorMedDagsverkNy } from './KalkulatorMedDagsverkNy';
 import { KalkulatorMedProsentNy } from './KalkulatorMedProsentNy';
 import { ToggleKnappPure } from 'nav-frontend-toggle';

--- a/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
+++ b/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
@@ -24,6 +24,15 @@ const KalkulatorNy: FunctionComponent<Props> = ({ restSykefraværshistorikk }) =
         scrollToBanner();
     }, []);
 
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            sendEvent('kalkulator', 'brukt i 30s')
+        }, 30000);
+        return () => {
+            clearTimeout(timer);
+        };
+    }, [sendEvent]);
+
     return (
         <div className="kalkulator-ny">
             <div className="kalkulator__wrapper">

--- a/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
+++ b/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
@@ -24,8 +24,6 @@ const KalkulatorNy: FunctionComponent<Props> = ({ restSykefraværshistorikk }) =
         scrollToBanner();
     }, []);
 
-    useMålingAvTidsbruk('kalkulator', 1, 2, 3, 4, 5, 6, 7, 8, 9);
-
     return (
         <div className="kalkulator-ny">
             <div className="kalkulator__wrapper">

--- a/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
+++ b/src/Kalkulator/KalkulatorNy/KalkulatorNy.tsx
@@ -4,7 +4,7 @@ import './KalkulatorNy.less';
 import { scrollToBanner } from '../../utils/scrollUtils';
 import { RestSykefraværshistorikk } from '../../api/sykefraværshistorikk';
 import { Kalkulatorvariant } from '../kalkulator-utils';
-import { useSendEvent } from '../../amplitude/amplitude';
+import { useMålingAvTidsbruk, useSendEvent } from '../../amplitude/amplitude';
 import { KalkulatorMedDagsverkNy } from './KalkulatorMedDagsverkNy';
 import { KalkulatorMedProsentNy } from './KalkulatorMedProsentNy';
 import { ToggleKnappPure } from 'nav-frontend-toggle';
@@ -24,14 +24,7 @@ const KalkulatorNy: FunctionComponent<Props> = ({ restSykefraværshistorikk }) =
         scrollToBanner();
     }, []);
 
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            sendEvent('kalkulator', 'brukt i 30s')
-        }, 30000);
-        return () => {
-            clearTimeout(timer);
-        };
-    }, [sendEvent]);
+    useMålingAvTidsbruk('kalkulator', 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
     return (
         <div className="kalkulator-ny">

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -99,21 +99,26 @@ export const useMålingAvTidsbruk = (
 ): void => {
     const sendEvent = useSendEvent();
     const skalSetteTimer = useRef(true);
+    const timers = useRef<NodeJS.Timeout[]>([]);
 
     useEffect(() => {
         if (skalSetteTimer.current) {
-            const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
+            skalSetteTimer.current = false;
+            timers.current = antallSekunderFørEventSendes.map((antallSekunder) =>
                 setTimeout(() => {
                     sendEvent(område, 'tidsbruk', {
                         sekunder: antallSekunder,
                     });
-                    console.log(område, antallSekunder);
                 }, antallSekunder * 1000)
             );
-
-            return () => {
-                timers.forEach((timer) => clearTimeout(timer));
-            };
         }
     }, [sendEvent, antallSekunderFørEventSendes, område]);
+
+    // Cleanup når komponenten unmountes
+    useEffect(
+        () => () => {
+            timers.current.forEach((timer) => clearTimeout(timer));
+        },
+        []
+    );
 };

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -1,6 +1,6 @@
 import amplitude from 'amplitude-js';
 import { RestStatus } from '../api/api-utils';
-import { useContext, useEffect, useRef } from 'react';
+import { useContext, useEffect } from 'react';
 import { RestBedriftsmetrikker } from '../api/bedriftsmetrikker';
 import { bedriftsmetrikkerContext } from '../utils/bedriftsmetrikkerContext';
 import { RestSykefraværshistorikk } from '../api/sykefraværshistorikk';
@@ -98,27 +98,22 @@ export const useMålingAvTidsbruk = (
     ...antallSekunderFørEventSendes: number[]
 ): void => {
     const sendEvent = useSendEvent();
-    const skalSetteTimer = useRef(true);
-    const timers = useRef<NodeJS.Timeout[]>([]);
 
     useEffect(() => {
-        if (skalSetteTimer.current) {
-            skalSetteTimer.current = false;
-            timers.current = antallSekunderFørEventSendes.map((antallSekunder) =>
-                setTimeout(() => {
-                    sendEvent(område, 'tidsbruk', {
-                        sekunder: antallSekunder,
-                    });
-                }, antallSekunder * 1000)
-            );
-        }
-    }, [sendEvent, antallSekunderFørEventSendes, område]);
+        const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
+            setTimeout(() => {
+                console.log('timer', område, antallSekunder);
+                sendEvent(område, 'tidsbruk', {
+                    sekunder: antallSekunder,
+                });
+            }, antallSekunder * 1000)
+        );
 
-    // Cleanup når komponenten unmountes
-    useEffect(
-        () => () => {
-            timers.current.forEach((timer) => clearTimeout(timer));
-        },
-        []
-    );
+        return () =>
+            timers.forEach((timer) => {
+                console.log('cleanup timer', område, timer);
+                clearTimeout(timer);
+            });
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    // Disabler eslint fordi dette alltid utelukkende skal kjøre på mounting av komponenten
 };

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -102,7 +102,6 @@ export const useMålingAvTidsbruk = (
     useEffect(() => {
         const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
             setTimeout(() => {
-                console.log('timer', område, antallSekunder);
                 sendEvent(område, 'tidsbruk', {
                     sekunder: antallSekunder,
                 });
@@ -111,7 +110,6 @@ export const useMålingAvTidsbruk = (
 
         return () =>
             timers.forEach((timer) => {
-                console.log('cleanup timer', område, timer);
                 clearTimeout(timer);
             });
     }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -1,6 +1,6 @@
 import amplitude from 'amplitude-js';
 import { RestStatus } from '../api/api-utils';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { RestBedriftsmetrikker } from '../api/bedriftsmetrikker';
 import { bedriftsmetrikkerContext } from '../utils/bedriftsmetrikkerContext';
 import { RestSykefraværshistorikk } from '../api/sykefraværshistorikk';
@@ -98,19 +98,22 @@ export const useMålingAvTidsbruk = (
     ...antallSekunderFørEventSendes: number[]
 ): void => {
     const sendEvent = useSendEvent();
+    const skalSetteTimer = useRef(true);
 
     useEffect(() => {
-        const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
-            setTimeout(() => {
-                sendEvent(område, 'tidsbruk', {
-                    sekunder: antallSekunder,
-                });
-                console.log(område, antallSekunder);
-            }, antallSekunder * 1000)
-        );
+        if (skalSetteTimer.current) {
+            const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
+                setTimeout(() => {
+                    sendEvent(område, 'tidsbruk', {
+                        sekunder: antallSekunder,
+                    });
+                    console.log(område, antallSekunder);
+                }, antallSekunder * 1000)
+            );
 
-        return () => {
-            timers.forEach((timer) => clearTimeout(timer));
-        };
+            return () => {
+                timers.forEach((timer) => clearTimeout(timer));
+            };
+        }
     }, [sendEvent, antallSekunderFørEventSendes, område]);
 };

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -1,6 +1,6 @@
 import amplitude from 'amplitude-js';
 import { RestStatus } from '../api/api-utils';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { RestBedriftsmetrikker } from '../api/bedriftsmetrikker';
 import { bedriftsmetrikkerContext } from '../utils/bedriftsmetrikkerContext';
 import { RestSykefraværshistorikk } from '../api/sykefraværshistorikk';
@@ -91,4 +91,26 @@ export const useSendEvent = (): SendEvent => {
 
     return (område: string, hendelse: string, data?: Object) =>
         sendEventDirekte(område, hendelse, { ...ekstraData, ...data });
+};
+
+export const useMålingAvTidsbruk = (
+    område: string,
+    ...antallSekunderFørEventSendes: number[]
+): void => {
+    const sendEvent = useSendEvent();
+
+    useEffect(() => {
+        const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
+            setTimeout(() => {
+                sendEvent(område, 'tidsbruk', {
+                    sekunder: antallSekunder,
+                });
+                console.log(område, antallSekunder);
+            }, antallSekunder * 1000)
+        );
+
+        return () => {
+            timers.forEach((timer) => clearTimeout(timer));
+        };
+    }, [sendEvent, antallSekunderFørEventSendes, område]);
 };

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -113,5 +113,6 @@ export const useMålingAvTidsbruk = (
                 clearTimeout(timer);
             });
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
-    // Disabler eslint fordi dette alltid utelukkende skal kjøre på mounting av komponenten
+    // eslint klager fordi vi ikke legger til alle variabler vi bruker i dependency-listen.
+    // Vi vil ikke legge dependencies der, fordi koden bare skal kjøre når komponenten mountes.
 };


### PR DESCRIPTION
Vi får ikke målt time on site ut av boksen i Amplitude ennå. Men dette er en OK workaround: Vi får vite om brukerne bruker mer enn 5 sekunder, 30 sekunder, 5 minutter eller lignende.