### PR TITLE
Bedre måling av tidsbruk + fiks feilbruk av useEffect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const AppContent: FunctionComponent = () => {
     const location = useLocation();
 
     useSetUserProperties();
-    useMålingAvTidsbruk('hele appen', 5, 30, 120, 300);
+    useMålingAvTidsbruk('hele appen', 1, 2, 3, 10);
 
     const brukerHarIkkeTilgangTilNoenOrganisasjoner =
         restOrganisasjoner.status === RestStatus.Suksess && restOrganisasjoner.data.length === 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const AppContent: FunctionComponent = () => {
     const location = useLocation();
 
     useSetUserProperties();
-    useMålingAvTidsbruk('hele appen', 1, 2, 3, 10);
+    useMålingAvTidsbruk('hele appen', 5, 30, 120, 300);
 
     const brukerHarIkkeTilgangTilNoenOrganisasjoner =
         restOrganisasjoner.status === RestStatus.Suksess && restOrganisasjoner.data.length === 0;

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -91,7 +91,7 @@ export const useSendEvent = (): SendEvent => {
         ekstra.current = {
             ...hentEkstraDataFraBedriftsmetrikker(restBedriftsmetrikker),
             ...hentEkstraDataFraSykefraværshistorikk(restSykefraværshistorikk),
-        }
+        };
     }, [restBedriftsmetrikker, restSykefraværshistorikk]);
 
     return (område: string, hendelse: string, data?: Object) =>
@@ -119,22 +119,18 @@ export const useMålingAvTidsbruk = (
     ...antallSekunderFørEventSendes: number[]
 ): void => {
     const sendEvent = useSendEvent();
+    const skalSendeEvent = useRef(true);
 
     useEffect(() => {
-        const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
-            setTimeout(() => {
-                console.log('tidsbruk', område, antallSekunder);
-                sendEvent(område, 'tidsbruk', {
-                    sekunder: antallSekunder,
-                });
-            }, antallSekunder * 1000)
-        );
-
-        return () =>
-            timers.forEach((timer) => {
-                clearTimeout(timer);
-            });
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
-    // eslint klager fordi vi ikke legger til alle variabler vi bruker i dependency-listen.
-    // Vi vil ikke legge dependencies der, fordi koden bare skal kjøre når komponenten mountes.
+        if (skalSendeEvent.current) {
+            skalSendeEvent.current = false;
+            antallSekunderFørEventSendes.map((antallSekunder) =>
+                setTimeout(() => {
+                    sendEvent(område, 'tidsbruk', {
+                        sekunder: antallSekunder,
+                    });
+                }, antallSekunder * 1000)
+            );
+        }
+    }, [område, antallSekunderFørEventSendes, sendEvent]);
 };

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -31,7 +31,6 @@ instance.init(getApiKey(), '', {
 export const setUserProperties = (properties: Object) => instance.setUserProperties(properties);
 
 export const sendEventDirekte = (område: string, hendelse: string, data?: Object): void => {
-    console.log(hendelse, data);
     instance.logEvent(['#sykefravarsstatistikk', område, hendelse].join('-'), data);
 };
 
@@ -84,18 +83,17 @@ export const useSendEvent = (): SendEvent => {
     const restSykefraværshistorikk = useContext<RestSykefraværshistorikk>(
         sykefraværshistorikkContext
     );
-
-    const ekstra = useRef<any>({});
+    const ekstradata = useRef<Object>({});
 
     useEffect(() => {
-        ekstra.current = {
+        ekstradata.current = {
             ...hentEkstraDataFraBedriftsmetrikker(restBedriftsmetrikker),
             ...hentEkstraDataFraSykefraværshistorikk(restSykefraværshistorikk),
         };
     }, [restBedriftsmetrikker, restSykefraværshistorikk]);
 
     return (område: string, hendelse: string, data?: Object) =>
-        sendEventDirekte(område, hendelse, { ...ekstra.current, ...data });
+        sendEventDirekte(område, hendelse, { ...ekstradata.current, ...data });
 };
 
 export const useSendSidevisningEvent = (område: string, orgnr: string | undefined) => {

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -31,6 +31,7 @@ instance.init(getApiKey(), '', {
 export const setUserProperties = (properties: Object) => instance.setUserProperties(properties);
 
 export const sendEventDirekte = (område: string, hendelse: string, data?: Object): void => {
+    console.log(hendelse, data);
     instance.logEvent(['#sykefravarsstatistikk', område, hendelse].join('-'), data);
 };
 
@@ -84,13 +85,17 @@ export const useSendEvent = (): SendEvent => {
         sykefraværshistorikkContext
     );
 
-    const ekstraData = {
-        ...hentEkstraDataFraBedriftsmetrikker(restBedriftsmetrikker),
-        ...hentEkstraDataFraSykefraværshistorikk(restSykefraværshistorikk),
-    };
+    const ekstra = useRef<any>({});
+
+    useEffect(() => {
+        ekstra.current = {
+            ...hentEkstraDataFraBedriftsmetrikker(restBedriftsmetrikker),
+            ...hentEkstraDataFraSykefraværshistorikk(restSykefraværshistorikk),
+        }
+    }, [restBedriftsmetrikker, restSykefraværshistorikk]);
 
     return (område: string, hendelse: string, data?: Object) =>
-        sendEventDirekte(område, hendelse, { ...ekstraData, ...data });
+        sendEventDirekte(område, hendelse, { ...ekstra.current, ...data });
 };
 
 export const useSendSidevisningEvent = (område: string, orgnr: string | undefined) => {
@@ -118,6 +123,7 @@ export const useMålingAvTidsbruk = (
     useEffect(() => {
         const timers = antallSekunderFørEventSendes.map((antallSekunder) =>
             setTimeout(() => {
+                console.log('tidsbruk', område, antallSekunder);
                 sendEvent(område, 'tidsbruk', {
                     sekunder: antallSekunder,
                 });

--- a/src/mocking/mock.ts
+++ b/src/mocking/mock.ts
@@ -57,7 +57,7 @@ if (mock.sykefraværsstatistikkApi) {
             };
         },
         {
-            delay: 500,
+            delay: 2000,
         }
     );
     fetchMock.get(


### PR DESCRIPTION
Ved bruk av useRef for ekstradata i useSendEvent, får sendEvent alltid med _nåværende_ tilgjengelig data, uavhengig av når den ble sendt. Spesielt nyttig når vi bruker setTimeout.