### PR TITLE
Fiks utsending av ia metrikker fra kalkulator og historikk

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
     deploy-to-dev:
         name: Deploy to dev-sbs
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/sende-ia-tjeneste-mottatt-ved-klikk-paa-kalkulator-og-historikk'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/fiks-utsending-av-ia-metrikker-fra-kalkulator-og-historikk'
         needs: compile-test-and-build
         runs-on: Ubuntu-20.04
         steps:

--- a/src/GrafOgTabell/GrafOgTabell.tsx
+++ b/src/GrafOgTabell/GrafOgTabell.tsx
@@ -15,12 +15,7 @@ import { RestAltinnOrganisasjoner } from '../api/altinnorganisasjon-api';
 import { useOrgnr } from '../utils/orgnr-hook';
 import EndringISykefravRsstatistikkenInfotekst from '../felleskomponenter/EndringISykefraværsstatistikkenInfotekst/EndringISykefraværsstatistikkenInfotekst';
 import Lenke from 'nav-frontend-lenker';
-import {
-    erIaTjenesterMetrikkerSendtForBedrift,
-    iaTjenesterMetrikkerErSendtForBedrift,
-    useSendIaTjenesteMetrikkEvent,
-} from '../metrikker/iatjenester';
-import { iaTjenesterMetrikkerContext } from '../metrikker/IaTjenesterMetrikkerContext';
+import { useSendIaTjenesteMetrikkMottattVedSidevisningEvent } from '../metrikker/iatjenester';
 
 interface Props {
     restSykefraværsstatistikk: RestSykefraværshistorikk;
@@ -30,33 +25,17 @@ interface Props {
 const GrafOgTabell: FunctionComponent<Props> = (props) => {
     const sendEvent = useSendEvent();
     const orgnr = useOrgnr();
-    const sendIaTjenesteMetrikkEvent = useSendIaTjenesteMetrikkEvent();
-    const context = useContext(iaTjenesterMetrikkerContext);
 
     useEffect(() => {
         scrollToBanner();
     }, []);
+
     useMålingAvTidsbruk('historikk', 5, 30, 60, 120);
     useSendSidevisningEvent('historikk', orgnr);
-
-    useEffect(() => {
-        if (!erIaTjenesterMetrikkerSendtForBedrift(orgnr, context.bedrifterSomHarSendtMetrikker)) {
-            sendIaTjenesteMetrikkEvent().then((isSent) => {
-                if (isSent) {
-                    context.setBedrifterSomHarSendtMetrikker(
-                        iaTjenesterMetrikkerErSendtForBedrift(
-                            orgnr,
-                            context.bedrifterSomHarSendtMetrikker
-                        )
-                    );
-                }
-            });
-        }
-    }, []);
-
-    const [grafEllerTabell, setGrafEllerTabell] = useState<'graf' | 'tabell'>('graf');
+    useSendIaTjenesteMetrikkMottattVedSidevisningEvent();
 
     const { restSykefraværsstatistikk } = props;
+    const [grafEllerTabell, setGrafEllerTabell] = useState<'graf' | 'tabell'>('graf');
 
     let innhold;
 

--- a/src/Kalkulator/Kalkulator/Kalkulator.tsx
+++ b/src/Kalkulator/Kalkulator/Kalkulator.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useContext, useEffect, useState } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
 import './Kalkulator.less';
 import { scrollToBanner } from '../../utils/scrollUtils';
@@ -13,12 +13,7 @@ import { KalkulatorMedDagsverk } from './KalkulatorMedDagsverk';
 import { KalkulatorMedProsent } from './KalkulatorMedProsent';
 import { ToggleKnappPure } from 'nav-frontend-toggle';
 import { useOrgnr } from '../../utils/orgnr-hook';
-import {
-    erIaTjenesterMetrikkerSendtForBedrift,
-    iaTjenesterMetrikkerErSendtForBedrift,
-    useSendIaTjenesteMetrikkEvent,
-} from '../../metrikker/iatjenester';
-import { iaTjenesterMetrikkerContext } from '../../metrikker/IaTjenesterMetrikkerContext';
+import { useSendIaTjenesteMetrikkMottattVedSidevisningEvent } from '../../metrikker/iatjenester';
 
 interface Props {
     restSykefraværshistorikk: RestSykefraværshistorikk;
@@ -30,30 +25,14 @@ const Kalkulator: FunctionComponent<Props> = ({ restSykefraværshistorikk }) => 
     );
     const orgnr = useOrgnr();
     const sendEvent = useSendEvent();
-    const sendIaTjenesteMetrikkEvent = useSendIaTjenesteMetrikkEvent();
-    const context = useContext(iaTjenesterMetrikkerContext);
 
     // kalkulator2 fordi det opprinnelige eventnavnet er merget med en annen event i Amplitude
     useMålingAvTidsbruk('kalkulator2', 5, 30, 60, 120);
     useSendSidevisningEvent('kalkulator', orgnr);
+    useSendIaTjenesteMetrikkMottattVedSidevisningEvent();
 
     useEffect(() => {
         scrollToBanner();
-    }, []);
-
-    useEffect(() => {
-        if (!erIaTjenesterMetrikkerSendtForBedrift(orgnr, context.bedrifterSomHarSendtMetrikker)) {
-            sendIaTjenesteMetrikkEvent().then((isSent) => {
-                if (isSent) {
-                    context.setBedrifterSomHarSendtMetrikker(
-                        iaTjenesterMetrikkerErSendtForBedrift(
-                            orgnr,
-                            context.bedrifterSomHarSendtMetrikker
-                        )
-                    );
-                }
-            });
-        }
     }, []);
 
     return (

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -41,7 +41,7 @@ type SendEvent = (område: string, hendelse: string, data?: Object) => void;
 
 export const amplitudeInstance = instance;
 
-export type EventData ={[key:string]: any}
+export type EventData = { [key: string]: any };
 
 export const setUserProperties = (properties: Object) => instance.setUserProperties(properties);
 
@@ -110,16 +110,15 @@ export const useMålingAvTidsbruk = (
 
 const useEkstraDataRef = (): MutableRefObject<Partial<Ekstradata>> => {
     const restVirksomhetMetadata = useContext<RestVirksomhetMetadata>(virksomhetMetadataContext);
-
     const restSykefraværshistorikk = useContext<RestSykefraværshistorikk>(
         sykefraværshistorikkContext
     );
     const restSummertSykefraværshistorikk = useContext<RestSummertSykefraværshistorikk>(
         summertSykefraværshistorikkContext
     );
+    const dataFraEnhetsregisteret = useContext<EnhetsregisteretState>(enhetsregisteretContext);
 
     const ekstradata = useRef<Partial<Ekstradata>>({});
-    const dataFraEnhetsregisteret = useContext<EnhetsregisteretState>(enhetsregisteretContext);
 
     useEffect(() => {
         ekstradata.current = {

--- a/src/metrikker/iatjenester.ts
+++ b/src/metrikker/iatjenester.ts
@@ -222,12 +222,15 @@ export const useSendIaTjenesteMetrikkMottattVedSidevisningEvent = () => {
         const eriaTjenesteMetrikkKlarTilUtsending = iaTjenesteMetrikk.fylkesnummer !== '';
 
         if (eriaTjenesteMetrikkKlarTilUtsending) {
+            console.log("[DEBUG] entering useEffect, eriaTjenesteMetrikkKlarTilUtsending?", eriaTjenesteMetrikkKlarTilUtsending);
             let timerFunc = setTimeout(() => {
+                const erIaTjenesterMetrikkerSendtForDenneBedrift = erIaTjenesterMetrikkerSendtForBedrift(
+                    orgnr,
+                    context.bedrifterSomHarSendtMetrikker
+                );
+                console.log("[DEBUG] erIaTjenesterMetrikkerSendtForDenneBedrift?", erIaTjenesterMetrikkerSendtForDenneBedrift);
                 if (
-                    !erIaTjenesterMetrikkerSendtForBedrift(
-                        orgnr,
-                        context.bedrifterSomHarSendtMetrikker
-                    )
+                    !erIaTjenesterMetrikkerSendtForDenneBedrift
                 ) {
                     sendIATjenesteMetrikk(iaTjenesteMetrikk).then((isSent) => {
                         if (isSent) {
@@ -242,6 +245,8 @@ export const useSendIaTjenesteMetrikkMottattVedSidevisningEvent = () => {
                 }
             }, 5000);
             return () => clearTimeout(timerFunc);
+        } else {
+            console.log("[DEBUG] NOT entering useEffect, eriaTjenesteMetrikkKlarTilUtsending?", eriaTjenesteMetrikkKlarTilUtsending);
         }
     }, [useOrgnr(), useContext<EnhetsregisteretState>(enhetsregisteretContext)]);
 };

--- a/src/metrikker/iatjenester.ts
+++ b/src/metrikker/iatjenester.ts
@@ -222,13 +222,11 @@ export const useSendIaTjenesteMetrikkMottattVedSidevisningEvent = () => {
         const eriaTjenesteMetrikkKlarTilUtsending = iaTjenesteMetrikk.fylkesnummer !== '';
 
         if (eriaTjenesteMetrikkKlarTilUtsending) {
-            console.log("[DEBUG] entering useEffect, eriaTjenesteMetrikkKlarTilUtsending?", eriaTjenesteMetrikkKlarTilUtsending);
             let timerFunc = setTimeout(() => {
                 const erIaTjenesterMetrikkerSendtForDenneBedrift = erIaTjenesterMetrikkerSendtForBedrift(
                     orgnr,
                     context.bedrifterSomHarSendtMetrikker
                 );
-                console.log("[DEBUG] erIaTjenesterMetrikkerSendtForDenneBedrift?", erIaTjenesterMetrikkerSendtForDenneBedrift);
                 if (
                     !erIaTjenesterMetrikkerSendtForDenneBedrift
                 ) {
@@ -245,8 +243,6 @@ export const useSendIaTjenesteMetrikkMottattVedSidevisningEvent = () => {
                 }
             }, 5000);
             return () => clearTimeout(timerFunc);
-        } else {
-            console.log("[DEBUG] NOT entering useEffect, eriaTjenesteMetrikkKlarTilUtsending?", eriaTjenesteMetrikkKlarTilUtsending);
         }
     }, [useOrgnr(), useContext<EnhetsregisteretState>(enhetsregisteretContext)]);
 };

--- a/src/metrikker/iatjenester.ts
+++ b/src/metrikker/iatjenester.ts
@@ -11,6 +11,7 @@ import {
 } from '../api/enhetsregisteret-api';
 import { useOrgnr } from '../utils/orgnr-hook';
 import { tilIsoDatoMedUtcTimezoneUtenMillis } from '../utils/app-utils';
+import { iaTjenesterMetrikkerContext } from './IaTjenesterMetrikkerContext';
 
 interface IaTjenesteMetrikkerEkstraData {
     orgnr: String;
@@ -79,10 +80,10 @@ const getIaTjenesterMetrikkerUrl = () => {
 const iaTjenesterMetrikkerAPI = `${getIaTjenesterMetrikkerUrl()}/innlogget/mottatt-iatjeneste`;
 export type EventData = { [key: string]: any };
 
-export const useSendIaTjenesteMetrikkEvent = (): (() => Promise<boolean>) => {
-    const ekstradata = useIaTjenesteMetrikkerEkstraDataRef();
-    const nåværendeOrgnr = useOrgnr();
-
+function byggIaTjenesteMottattMetrikk(
+    nåværendeOrgnr: string | undefined,
+    ekstradata: React.MutableRefObject<Partial<IaTjenesteMetrikkerEkstraData>>
+) {
     const iaTjenesteMetrikk: IatjenesteMetrikk = {
         orgnr: nåværendeOrgnr ? nåværendeOrgnr : '',
         antallAnsatte: ekstradata.current.antallAnsatte ? ekstradata.current.antallAnsatte : 0,
@@ -109,6 +110,13 @@ export const useSendIaTjenesteMetrikkEvent = (): (() => Promise<boolean>) => {
             : '',
         tjenesteMottakkelsesdato: tilIsoDatoMedUtcTimezoneUtenMillis(new Date()),
     };
+    return iaTjenesteMetrikk;
+}
+
+export const useSendIaTjenesteMetrikkEvent = (): (() => Promise<boolean>) => {
+    const ekstradata = useIaTjenesteMetrikkerEkstraDataRef();
+    const nåværendeOrgnr = useOrgnr();
+    const iaTjenesteMetrikk = byggIaTjenesteMottattMetrikk(nåværendeOrgnr, ekstradata);
 
     return () => sendIATjenesteMetrikk(iaTjenesteMetrikk);
 };
@@ -139,21 +147,27 @@ export const sendIATjenesteMetrikk = async (iatjeneste: IatjenesteMetrikk) => {
 const useIaTjenesteMetrikkerEkstraDataRef = (): MutableRefObject<
     Partial<IaTjenesteMetrikkerEkstraData>
 > => {
-    const iaTjenesterMetrikkerEkstraData = useRef<Partial<IaTjenesteMetrikkerEkstraData>>({});
-
     const restVirksomhetMetadata = useContext<RestVirksomhetMetadata>(virksomhetMetadataContext);
     const dataFraEnhetsregisteret = useContext<EnhetsregisteretState>(enhetsregisteretContext);
+    const iaTjenesterMetrikkerEkstraData = useRef<Partial<IaTjenesteMetrikkerEkstraData>>({});
 
     useEffect(() => {
-        iaTjenesterMetrikkerEkstraData.current = {
-            ...getIaTjenesteMetrikkerEkstraDataFraVirksomhetMetadata(restVirksomhetMetadata),
-            ...getIaTjenesteMetrikkerEkstraDataFraEnhetsregisteret(
-                dataFraEnhetsregisteret.restOverordnetEnhet,
-                dataFraEnhetsregisteret.restUnderenhet,
-                restVirksomhetMetadata
-            ),
-        };
+        if (
+            restVirksomhetMetadata.status === RestStatus.Suksess &&
+            dataFraEnhetsregisteret.restUnderenhet.status === RestStatus.Suksess &&
+            dataFraEnhetsregisteret.restOverordnetEnhet.status === RestStatus.Suksess
+        ) {
+            iaTjenesterMetrikkerEkstraData.current = {
+                ...getIaTjenesteMetrikkerEkstraDataFraVirksomhetMetadata(restVirksomhetMetadata),
+                ...getIaTjenesteMetrikkerEkstraDataFraEnhetsregisteret(
+                    dataFraEnhetsregisteret.restOverordnetEnhet,
+                    dataFraEnhetsregisteret.restUnderenhet,
+                    restVirksomhetMetadata
+                ),
+            };
+        }
     }, [restVirksomhetMetadata, dataFraEnhetsregisteret]);
+
     return iaTjenesterMetrikkerEkstraData;
 };
 
@@ -196,4 +210,38 @@ const getIaTjenesteMetrikkerEkstraDataFraEnhetsregisteret = (
         };
     }
     return {};
+};
+
+export const useSendIaTjenesteMetrikkMottattVedSidevisningEvent = () => {
+    const context = useContext(iaTjenesterMetrikkerContext);
+    const ekstradata = useIaTjenesteMetrikkerEkstraDataRef();
+    const orgnr = useOrgnr();
+
+    useEffect(() => {
+        const iaTjenesteMetrikk = byggIaTjenesteMottattMetrikk(orgnr, ekstradata);
+        const eriaTjenesteMetrikkKlarTilUtsending = iaTjenesteMetrikk.fylkesnummer !== '';
+
+        if (eriaTjenesteMetrikkKlarTilUtsending) {
+            let timerFunc = setTimeout(() => {
+                if (
+                    !erIaTjenesterMetrikkerSendtForBedrift(
+                        orgnr,
+                        context.bedrifterSomHarSendtMetrikker
+                    )
+                ) {
+                    sendIATjenesteMetrikk(iaTjenesteMetrikk).then((isSent) => {
+                        if (isSent) {
+                            context.setBedrifterSomHarSendtMetrikker(
+                                iaTjenesterMetrikkerErSendtForBedrift(
+                                    orgnr,
+                                    context.bedrifterSomHarSendtMetrikker
+                                )
+                            );
+                        }
+                    });
+                }
+            }, 5000);
+            return () => clearTimeout(timerFunc);
+        }
+    }, [useOrgnr(), useContext<EnhetsregisteretState>(enhetsregisteretContext)]);
 };


### PR DESCRIPTION
Det manglet en depth på resultat av et REST kall i en av våre useEffect hooks slik at metrikkene sendes med alt nøvendig data. Slettet en del duplisering ved utsending av metrikker i `Kalkulator` og `GrafOgTabell` (flyttet felles koden til `iatjenester.ts`)