### PR TITLE
Bugfix: sektor sendes feil til Amplitude

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
     deploy-to-dev:
         name: Deploy to dev-sbs
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dependabot-sep-21'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bugfix/sektor_i_amplitude'
         needs: compile-test-and-build
         runs-on: Ubuntu-20.04
         steps:
@@ -53,7 +53,7 @@ jobs:
                   PRINT_PAYLOAD: true
     deploy-to-labs-gcp:
         name: Deploy to labs-gcp
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dependabot-sep-21'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bugfix/sektor_i_amplitude'
         needs: compile-test-and-build
         runs-on: Ubuntu-20.04
         steps:

--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -10,8 +10,8 @@ import { enhetsregisteretContext, EnhetsregisteretState } from '../utils/enhetsr
 import {
     Ekstradata,
     getEkstraDataFraEnhetsregisteret,
-    getEkstraDataFraSykefraværshistorikk,
     getEkstraDataFraSummertSykefraværshistorikk,
+    getEkstraDataFraSykefraværshistorikk,
     getEkstraDataFraVirksomhetMetadata,
 } from './ekstradata';
 
@@ -83,7 +83,9 @@ export const useSendSidevisningEvent = (område: string, orgnr: string | undefin
     useEffect(() => {
         if (skalSendeEvent.current) {
             skalSendeEvent.current = false;
-            sendEvent(område, 'vist');
+
+            // Setter timeout på eventet, slik at alle dataene fra "ekstradata" rekker å laste inn før eventet sendes.
+            setTimeout(() => sendEvent(område, 'vist'), 2000);
         }
     }, [orgnr, område, sendEvent]);
 };


### PR DESCRIPTION
Oppgave: https://trello.com/c/Ikv7Thbk

Løsning: Timout på sidevisning-eventet, slik at data fra Enhetsregistret rekker å laste inn i "ekstradata" 
