### PR TITLE
Fjerner kall til forenklet IA-tjenestemtrikker-endepunkt.

### DIFF
--- a/src/metrikker/iatjenester.ts
+++ b/src/metrikker/iatjenester.ts
@@ -43,7 +43,7 @@ const getIaTjenesterMetrikkerUrl = () => {
     }
 };
 
-const iaTjenesterMetrikkerAPI = `${getIaTjenesterMetrikkerUrl()}/innlogget/forenklet/mottatt-iatjeneste`;
+const iaTjenesterMetrikkerAPI = `${getIaTjenesterMetrikkerUrl()}/innlogget/mottatt-iatjeneste`;
 
 function byggIaTjenesteMottattMetrikk(
     nåværendeOrgnr: string | undefined,


### PR DESCRIPTION
https://trello.com/c/dQe6u9wl

å merges etter at https://github.com/navikt/ia-tjenester-metrikker/pull/49 er ferdig 