### PR TITLE
Legg til concurrent builds som kan stoppes i Github Actions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -5,6 +5,10 @@ on: [push]
 env:
     IMAGE: docker.pkg.github.com/${{ github.repository }}/sykefravarsstatistikk:${{ github.sha }}
 
+concurrency:
+    group: build-deploy-on-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     compile-test-and-build:
         name: Build and run tests


### PR DESCRIPTION
Siden concurrency.group bruker branchen eller tag i navnet, så vil ikkebranch-bygg konflikte med hverandre ettersom de kun kan stoppes hvis de bygger på samme branch.