### PR TITLE
Legg til outbound rule i accesspolicy

### DIFF
--- a/nais/labs-gcp.yaml
+++ b/nais/labs-gcp.yaml
@@ -21,5 +21,8 @@ spec:
         initialDelay: 10
     accessPolicy:
         outbound:
+            rules:
+                - application: sykefravarsstatistikk-api
+                  namespace: arbeidsgiver
             external:
                 - host: dekoratoren.dev.nav.no


### PR DESCRIPTION
Slik jeg forstår må dette gjøres, samt at det senere må legges til en inbound accesspolicy i sykefravarsstatistikk-api som tar imot requester. Dette for at tokenx skal virke, når den er migrert til gcp. 

Har litt lyst til å teste den bare i gcp først før vi gjør det mot prod også.