### PR TITLE
Vis navn og orgnummer i tittel

### DIFF
--- a/src/Forside/SammenligningIngress/SammenligningIngress.less
+++ b/src/Forside/SammenligningIngress/SammenligningIngress.less
@@ -2,6 +2,7 @@
 
 .sammenligning-ingress {
     &__tittel {
+        padding-top: 1rem;
         padding-bottom: 1rem;
     }
 

--- a/src/Forside/Sammenligningspaneler/Sammenligningspaneler.less
+++ b/src/Forside/Sammenligningspaneler/Sammenligningspaneler.less
@@ -22,7 +22,11 @@
         display: none;
     }
 
-    &__print-header {
+    &__header {
+        display: block;
+    }
+
+    &__href {
         display: none;
     }
 
@@ -45,15 +49,8 @@
             display: none;
         }
 
-        &__print-header {
-            display: block;
-        }
-
         &__href {
-            padding-bottom: 1rem;
-        }
-
-        &__print-tittel {
+            display: block;
             padding-bottom: 1rem;
         }
     }

--- a/src/Forside/Sammenligningspaneler/Sammenligningspaneler.tsx
+++ b/src/Forside/Sammenligningspaneler/Sammenligningspaneler.tsx
@@ -1,9 +1,8 @@
 import React, { FunctionComponent, ReactNode, useRef } from 'react';
 import './Sammenligningspaneler.less';
 import ReactToPrint from 'react-to-print';
-import { Alert } from '@navikt/ds-react';
+import { Alert, BodyShort, Heading } from '@navikt/ds-react';
 import { RestStatus } from '../../api/api-utils';
-import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
 import { RestAltinnOrganisasjoner } from '../../api/altinnorganisasjon-api';
 import { useOrgnr } from '../../hooks/useOrgnr';
 import { sendKnappEvent } from '../../amplitude/events';
@@ -33,13 +32,13 @@ export const Sammenligningspaneler: FunctionComponent<{
                 </Alert>
             )}
             <div className="sammenligningspaneler" ref={panelRef}>
-                <div className="sammenligningspaneler__print-header">
-                    <Normaltekst className="sammenligningspaneler__href">
+                <div className="sammenligningspaneler__header">
+                    <BodyShort className="sammenligningspaneler__href">
                         {window.location.href}
-                    </Normaltekst>
-                    <Systemtittel tag="h1" className="sammenligningspaneler__print-tittel">
+                    </BodyShort>
+                    <Heading size="medium" level="1">
                         Sykefraværsstatistikk for {navnPåVirksomhet} ({orgnr})
-                    </Systemtittel>
+                    </Heading>
                 </div>
                 <ReactToPrint
                     onBeforePrint={() => {


### PR DESCRIPTION
Navn og orgnummer lagt til på toppen av siden

![Capture-2023-05-10-121304](https://github.com/navikt/sykefravarsstatistikk/assets/6861919/b3d163f2-1277-4338-a60d-4138beb9c1dd)
