### PR TITLE
Legg til tabell i print

### DIFF
--- a/src/Forside/EkspanderbarSammenligning/EkspanderbarSammenligning.less
+++ b/src/Forside/EkspanderbarSammenligning/EkspanderbarSammenligning.less
@@ -3,10 +3,4 @@
         padding-top: 2rem;
         padding-bottom: 1rem;
     }
-
-    @media print {
-        &__sammenligning-totalt {
-            page-break-after: always;
-        }
-    }
 }

--- a/src/Forside/Forside.tsx
+++ b/src/Forside/Forside.tsx
@@ -34,6 +34,7 @@ export const Forside: FunctionComponent<SykefraværAppData> = (appData) => {
                     restAltinnOrganisasjonerMedStatistikktilgang={
                         appData.altinnOrganisasjonerMedStatistikktilgang
                     }
+                    restSykefraværshistorikk={appData.sykefraværshistorikk}
                 >
                     <EkspanderbarSammenligning
                         aggregertStatistikk={appData.aggregertStatistikk}

--- a/src/Forside/SammenligningMedBransje/BransjeSammenligningspanel.less
+++ b/src/Forside/SammenligningMedBransje/BransjeSammenligningspanel.less
@@ -148,6 +148,10 @@
     }
 
     @media print {
+        ~ .bransje-sammenligningspanel:nth-of-type(odd) {
+          page-break-after: always;
+        }
+
         &__print-innhold {
             display: block;
         }

--- a/src/Forside/SammenligningMedBransje/BransjeSammenligningspanel.less
+++ b/src/Forside/SammenligningMedBransje/BransjeSammenligningspanel.less
@@ -148,6 +148,7 @@
     }
 
     @media print {
+        // Gir tabellen en egen side
         ~ .bransje-sammenligningspanel:nth-of-type(odd) {
           page-break-after: always;
         }

--- a/src/Forside/Sammenligningspaneler/Sammenligningspaneler.less
+++ b/src/Forside/Sammenligningspaneler/Sammenligningspaneler.less
@@ -7,6 +7,10 @@
     border-radius: 0.25rem;
     position: relative;
 
+    &__kun-print {
+        display: none;
+    }
+
     &__info-eller-feilmelding {
         width: 100%;
         margin-bottom: 1.5rem;
@@ -37,6 +41,9 @@
     }
 
     @media print {
+        &__kun-print {
+            display: block;
+        }
         &__knapp {
             display: none;
         }

--- a/src/Forside/Sammenligningspaneler/Sammenligningspaneler.tsx
+++ b/src/Forside/Sammenligningspaneler/Sammenligningspaneler.tsx
@@ -72,7 +72,11 @@ export const Sammenligningspaneler: FunctionComponent<{
                     )}
                 />
                 {children}
-                {!!tabellProps && <Tabell {...tabellProps} />}
+                {!!tabellProps && (
+                    <div className="sammenligningspaneler__kun-print">
+                        <Tabell {...tabellProps} />
+                    </div>
+                )}
             </div>
         </>
     );

--- a/src/GrafOgTabell/Tabell/Tabell.tsx
+++ b/src/GrafOgTabell/Tabell/Tabell.tsx
@@ -8,7 +8,7 @@ import {
     KvartalsvisSammenligning,
 } from '../../utils/sykefraværshistorikk-utils';
 
-interface TabellProps {
+export interface TabellProps {
     kvartalsvisSammenligning: KvartalsvisSammenligning[];
     harOverordnetEnhet: boolean;
     bransjeEllerNæringLabel: BransjeEllerNæringLabel;


### PR DESCRIPTION
Skulle gjerne ikke "duplisert" grafen, men ettersom den er gjemt så langt nede i komponenttreet så vil det her også kreve en god del refaktorering for at det skal blir noe særlig bedre.

[Eksempel på print PDF](https://github.com/navikt/sykefravarsstatistikk/files/11460850/Sykefravaersstatistikk.pdf)
